### PR TITLE
Adapt to Coq PR #15537: schemes eq_rect & cie have different automatically generated names

### DIFF
--- a/src/equality.v
+++ b/src/equality.v
@@ -47,9 +47,9 @@ Arguments eq {A} x _.
 Prenex Implicits eq_refl.
 Arguments eq_refl {A x}, {A} x.
 
-Arguments eq_ind [A] x P _ y _.
-Arguments eq_rec [A] x P _ y _.
-Arguments eq_rect [A] x P _ y _.
+Arguments eq_ind [A] x P _ y _ : rename.
+Arguments eq_rec [A] x P _ y _ : rename.
+Arguments eq_rect [A] x P _ y _ : rename.
 
 Definition eq_rect_dep A (x: A) (P: forall y, x = y -> Type) (ih: P x (eq_refl x)) y (e: x = y) : P y e :=
   let: eq_refl := e in ih.


### PR DESCRIPTION
This is a consequence of fixing a naming bug in coq/coq#15537. It now requires an explicit `rename` flag in the subsequent calls to `Arguments` for `eq` induction schemes

A priori, I don't see other consequences of the naming fix (except on printing, where sometimes, especially in `return` clauses, `y` will be displayed `a`).

If ok with the change, this is backward-compatible and can be merged as soon as now.
